### PR TITLE
adjust java examples re notes

### DIFF
--- a/source/includes/_credit_notes.md.erb
+++ b/source/includes/_credit_notes.md.erb
@@ -144,19 +144,19 @@ client.CreditNote.create(
 
 ```java
 CreditNote creditNote = invoiced.newCreditNote();
-creditNote.customer = 15444;
-creditNote.invoice = 46225;
+creditNote.customer = 15444L;
+creditNote.invoice = 46225L;
 LineItem[] items = new LineItem[2];
 items[0] = new LineItem();
 items[0].name = "Copy paper, Case";
-items[0].quantity = 1;
-items[0].unitCost = 45;
+items[0].quantity = 1D;
+items[0].unitCost = 45D;
 items[1] = new LineItem();
 items[1].catalogItem = "delivery";
-items[1].quantity = 1;
+items[1].quantity = 1D;
 Tax[] taxes = new Tax[1];
 taxes[0] = new Tax();
-taxes[0].amount = 3.85;
+taxes[0].amount = 3.85D;
 creditNote.items = items;
 creditNote.taxes = taxes;
 creditNote.create();

--- a/source/includes/_credit_notes.md.erb
+++ b/source/includes/_credit_notes.md.erb
@@ -144,19 +144,19 @@ client.CreditNote.create(
 
 ```java
 CreditNote creditNote = invoiced.newCreditNote();
-creditNote.customer = 15444L;
-creditNote.invoice = 46225L;
+creditNote.customer = 15444;
+creditNote.invoice = 46225;
 LineItem[] items = new LineItem[2];
 items[0] = new LineItem();
 items[0].name = "Copy paper, Case";
-items[0].quantity = 1D;
-items[0].unitCost = 45D;
+items[0].quantity = 1;
+items[0].unitCost = 45;
 items[1] = new LineItem();
 items[1].catalogItem = "delivery";
-items[1].quantity = 1D;
+items[1].quantity = 1;
 Tax[] taxes = new Tax[1];
 taxes[0] = new Tax();
-taxes[0].amount = 3.85D;
+taxes[0].amount = 3.85;
 creditNote.items = items;
 creditNote.taxes = taxes;
 creditNote.create();

--- a/source/includes/_credit_notes.md.erb
+++ b/source/includes/_credit_notes.md.erb
@@ -526,7 +526,7 @@ creditNote.void()
 ```
 
 ```java
-creditNote.void();
+creditNote.voidCreditNote();
 ```
 
 > The above command returns JSON structured like this:

--- a/source/includes/_estimates.md.erb
+++ b/source/includes/_estimates.md.erb
@@ -589,7 +589,7 @@ estimate.void()
 ```
 
 ```java
-estimate.void();
+estimate.voidEstimate();
 ```
 
 > The above command returns JSON structured like this:

--- a/source/includes/_invoicing.md.erb
+++ b/source/includes/_invoicing.md.erb
@@ -908,7 +908,7 @@ invoice.void()
 ```
 
 ```java
-invoice.void();
+invoice.voidInvoice();
 ```
 
 > The above command returns JSON structured like this:

--- a/source/includes/_notes.md.erb
+++ b/source/includes/_notes.md.erb
@@ -72,9 +72,9 @@ client.Note.create(
 ```
 
 ```java
-Note note = invoiced.newNote();
-note.invoice_id = 46225;
-note.notes = "Customer called 10/1, clarified account terms."
+Invoice invoice = invoiced.newInvoice().retrieve(46225);
+Note note = invoice.newNote();
+note.notes = "Customer called 10/1, clarified account terms.";
 note.create();
 ```
 
@@ -138,7 +138,8 @@ notes = client.Invoice.retrieve_notes("{INVOICE_ID}")
 ```
 
 ```java
-EntityList<Note> notes = invoiced.newInvoice().retrieveNotes({INVOICE_ID});
+Invoice invoice = invoiced.newInvoice().retrieve({INVOICE_ID});
+EntityList<Note> notes = invoice.newNote().listAll();
 ```
 
 > The above command returns JSON structured like this:

--- a/source/includes/_payments.md.erb
+++ b/source/includes/_payments.md.erb
@@ -570,7 +570,7 @@ curl 'https://api.invoiced.com/charges' \
 
 ```ruby
 
-invoiced.Charge.create(
+charge = transaction.initiate_charge(
   :customer => 401558,
   :currency => "usd",
   :amount => 2000,
@@ -589,7 +589,7 @@ invoiced.Charge.create(
 ```php
 <?php
 
-$invoiced->Charge->create([
+$charge = $transaction->initiateCharge([
   'customer' => 401558,
   'currency' => "usd",
   'amount' => 2000,
@@ -606,7 +606,7 @@ $invoiced->Charge->create([
 ```
 
 ```python
-client.Charge.create(
+charge = transaction.initiate_charge(
   customer = 401558,
   currency = "usd",
   amount = 2000,
@@ -623,21 +623,21 @@ client.Charge.create(
 ```
 
 ```java
-Charge charge = invoiced.newCharge();
-charge.customer = 401558;
-charge.currency = "usd";
-charge.amount = 2000;
-charge.splits = [...]; // excluded for brevity
-charge.method = "credit_card";
+ChargeRequest chargeRequest = invoiced.newChargeRequest();
+chargeRequest.customer = 401558;
+chargeRequest.currency = "usd";
+chargeRequest.amount = 2000;
+chargeRequest.splits = [...]; // excluded for brevity
+chargeRequest.method = "credit_card";
 
 // (Tokenized Payment Info)
-charge.invoiced_token = "acdf7f31da641970cdb9c6c46a373577";
+chargeRequest.invoiced_token = "acdf7f31da641970cdb9c6c46a373577";
 
 // (Saved Payment Source)
-charge.payment_source_type = "card";
-charge.payment_source_id = 1234;
+chargeRequest.payment_source_type = "card";
+chargeRequest.payment_source_id = 1234;
 
-charge.create();
+Transaction charge = invoiced.newTransaction().initiateCharge(chargeRequest);
 ```
 
 > The above command returns JSON structured like this:


### PR DESCRIPTION
The purpose of this change is to conform the syntax of the Java library `Note` class with its existing `Contact` class. Because this changes a code example I felt it prudent to PR.